### PR TITLE
Add simple Flagsmith query client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-"# featureflag" 
+# featureflag
+
+Minimal Python client for querying a flag from a Flagsmith server.
+
+## Requirements
+
+- Python 3.8+
+- [`requests`](https://pypi.org/project/requests/) library
+
+## Usage
+
+1. Set the environment variable `FLAGSMITH_ENVIRONMENT_KEY` to your Flagsmith environment key.
+2. Optionally set `FLAGSMITH_URL` if the server is not at `http://localhost:8000`.
+3. Run the client to check a flag:
+
+```bash
+python flagsmith_client.py my_flag_name
+```
+
+The script will print `True` or `False` depending on whether the flag is enabled.

--- a/flagsmith_client.py
+++ b/flagsmith_client.py
@@ -1,0 +1,39 @@
+import os
+import requests
+
+
+def get_flag(flag_name, default=False):
+    """Return the boolean value of a feature flag from Flagsmith."""
+    base_url = os.getenv("FLAGSMITH_URL", "http://localhost:8000")
+    env_key = os.getenv("FLAGSMITH_ENVIRONMENT_KEY")
+    headers = {}
+    if env_key:
+        headers["X-Environment-Key"] = env_key
+
+    response = requests.get(f"{base_url}/api/v1/flags/", headers=headers)
+    response.raise_for_status()
+
+    for flag in response.json():
+        if flag.get("feature", {}).get("name") == flag_name:
+            return flag.get("enabled", default)
+    return default
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Query a Flagsmith flag")
+    parser.add_argument("flag", help="Name of the flag to query")
+    parser.add_argument("--default", dest="default", action="store_true",
+                        help="Default value if flag is not found or request fails")
+
+    args = parser.parse_args()
+    try:
+        enabled = get_flag(args.flag, args.default)
+        print(enabled)
+    except Exception as exc:
+        print(args.default)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small Python client to query Flagsmith flags via HTTP
- document how to use the client

## Testing
- `python3 -m py_compile flagsmith_client.py`
- `python3 flagsmith_client.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python3 -m pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847f73d2b20832e8d258cf628fa48d9